### PR TITLE
P2P feefilter: add extra details

### DIFF
--- a/_autocrossref.yaml
+++ b/_autocrossref.yaml
@@ -27,6 +27,8 @@ DER-formatted: der
 ECDSA:
 epoch time: unix epoch time
 '`expires`': pp expires
+'`feefilter` message': feefilter message
+'`feefilter` messages': feefilter message
 fiat:
 '`filteradd` message': filteradd message
 '`filteradd` messages': filteradd message
@@ -172,6 +174,7 @@ BIP66:
 BIP70:
 BIP71:
 BIP72:
+BIP133:
 
 ## CVEs
 CVE-2012-2459:
@@ -361,4 +364,6 @@ Bitcoin Core 0.9.0:
 Bitcoin Core 0.9.1:
 Bitcoin Core 0.9.3:
 Bitcoin Core 0.10.0:
+Bitcoin Core 0.12.0:
+Bitcoin Core 0.13.0:
 Bitcoin Core master:

--- a/_config.yml
+++ b/_config.yml
@@ -494,6 +494,7 @@ devsearches:
     - "addr":  "/en/developer-reference#addr"
     - "alert":  "/en/developer-reference#alert"
     - "block": "/en/developer-reference#block"
+    - "feefilter": "/en/developer-reference#feefilter"
     - "filteradd": "/en/developer-reference#filteradd"
     - "filterclear": "/en/developer-reference#filterclear"
     - "filterload": "/en/developer-reference#filterload"

--- a/_includes/devdoc/ref_p2p_networking.md
+++ b/_includes/devdoc/ref_p2p_networking.md
@@ -801,8 +801,8 @@ The `feefilter` message is a request to the receiving peer to not relay any
 transaction inv messages to the sending peer where the fee rate for the
 transaction is below the fee rate specified in the feefilter message.
 
-`feefilter` was introduced in V0.13.0 following the introduction
-of mempool limiting in V0.12.0. Mempool limiting provides protection against
+`feefilter` was introduced in Bitcoin Core 0.13.0 following the introduction
+of mempool limiting in Bitcoin Core 0.12.0. Mempool limiting provides protection against
 attacks and spam transactions that have low fee rates and are unlikely to be
 included in mined blocks. The `feefilter` messages allows a node to inform its
 peers that it will not accept transactions below a specified fee rate into
@@ -811,7 +811,7 @@ transactions below that fee rate to that node.
 
 | Bytes | Name    | Data Type | Description
 |-------|---------|-----------|---------------
-| 8     | feerate | uint64_t  | The fee rate (in Satoshis per kilobyte) under which transactions should not be relayed to this peer.
+| 8     | feerate | uint64_t  | The fee rate (in satoshis per kilobyte) below which transactions should not be relayed to this peer.
 
 The receiving peer may choose to ignore the message and not filter transaction
 inv messages.
@@ -820,7 +820,15 @@ The fee filter is additive with bloom filters. If an SPV client loads a bloom fi
 
 inv messages generated from a mempool message are subject to a fee filter if it exists.
 
+The annotated hexdump below shows a `feefilter` message. (The message
+header has been omitted.)
+
 {% endautocrossref %}
+
+{% highlight text %}
+7cbd000000000000 ... satoshis per kilobyte: 48,508
+{% endhighlight %}
+
 
 #### FilterAdd
 {% include helpers/subhead-links.md %}

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -160,6 +160,7 @@ http://opensource.org/licenses/MIT.
 [addr message]: /en/developer-reference#addr "The P2P network message which relays IP addresses and port numbers of active nodes to other nodes and clients, allowing decentralized peer discovery."
 [alert message]: /en/developer-reference#alert "The P2P network message which sends alerts in case of major software problems."
 [block message]: /en/developer-reference#block "The P2P network message which sends a serialized block"
+[feefilter message]: /en/developer-reference#feefilter "The P2P network message which requests the receiving peer not relay any transactions below the specified fee rate"
 [filteradd message]: /en/developer-reference#filteradd "A P2P protocol message used to add a data element to an existing bloom filter."
 [filterclear message]: /en/developer-reference#filterclear "A P2P protocol message used to remove an existing bloom filter."
 [filterload message]: /en/developer-reference#filterclear "A P2P protocol message used to send a filter to a remote peer, requesting that they only send transactions which match the filter."
@@ -216,8 +217,9 @@ http://opensource.org/licenses/MIT.
 [Bitcoin Core 0.9.1]: /en/release/v0.9.1
 [Bitcoin Core 0.9.2]: /en/release/v0.9.2
 [Bitcoin Core 0.9.3]: /en/release/v0.9.3
-{% comment %}<!-- TODOv0.10 update this to point to 0.10 release notes when released -->{% endcomment %}
-[Bitcoin Core 0.10.0]: https://github.com/bitcoin/bitcoin/tree/0.10
+[Bitcoin Core 0.10.0]: /en/release/v0.10.0
+[Bitcoin Core 0.12.0]: /en/release/v0.12.0
+[Bitcoin Core 0.13.0]: /en/release/v0.13.0
 [bitcoin URI subsection]: /en/developer-guide#bitcoin-uri
 [bitcoind initial setup]: /en/developer-examples
 [bitcoinpdf]: https://bitcoin.org/en/bitcoin-paper
@@ -289,6 +291,7 @@ http://opensource.org/licenses/MIT.
 [BIP71]: https://github.com/bitcoin/bips/blob/master/bip-0071.mediawiki
 [BIP72]: https://github.com/bitcoin/bips/blob/master/bip-0072.mediawiki
 [BIP130]: https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki
+[BIP133]: https://github.com/bitcoin/bips/blob/master/bip-0133.mediawiki
 [CVE-2012-2459]: https://en.bitcoin.it/wiki/CVEs#CVE-2012-2459
 [RFC5737]: http://tools.ietf.org/html/rfc5737
 [secp256k1]: http://www.secg.org/sec2-v2.pdf


### PR DESCRIPTION
- Add annotated hex example collected from a live mainnet node using Wireshark.

- Add search box entry to `_config.yaml` and autocrossref entry to `_include/references.md` and `_autocrossref.yaml`

- Add Bitcoin Core 0.12/0.13 cross links by changing `V0.12.0` to `Bitcoin Core 0.12.0` and similar for 0.13.0

- Add BIP133 to the autocrossreference links to it gets automatically linkified

- Lowercase `satoshi` (unit) per Bitcoin.org [style guide](https://github.com/bitcoin-dot-org/bitcoin.org/wiki/Documentation-Style-Guide)

As I'll mention in the main PR, I tested this PR on a preview and your documentation looked great, thanks!  Here's a screenshot of the preview:

![2016-12-21-21_32_24_535332643](https://cloud.githubusercontent.com/assets/61096/21413409/106c1706-c7c5-11e6-8f96-b6d99576b5b2.png)